### PR TITLE
Interim fix north/south compass fix.

### DIFF
--- a/Source/ViewModels/NavigationViewModel.js
+++ b/Source/ViewModels/NavigationViewModel.js
@@ -111,7 +111,26 @@ define([
                 that.showCompass = true && that.enableCompass;
 
                 that._unsubcribeFromPostRender = that.terria.scene.postRender.addEventListener(function() {
-                    that.heading = that.terria.scene.camera.heading;
+                    /*
+                     * "magic" limits for pitch and roll found by trial and error
+                     *
+                     * cos(2ⁿп) === 1, where n is natural number
+                     *
+                     * default camera init is { heading: 0,  pitch: -п/2, roll: 0 }
+                     * where the -90 pitch causes "look down at earth"
+                     *
+                     * mouse interaction rarely produces roll "far" from 2ⁿп, but
+                     * cesium sets roll value that differs significantly in certain cases,
+                     * when cesium seems to "split" true heading value between heading and roll.
+                     */
+                    var heading = that.terria.scene.camera.heading;
+                    var roll = that.terria.scene.camera.roll;
+                    var near2п = CesiumMath.equalsEpsilon(Math.cos(roll), 1, CesiumMath.EPSILON1);
+                    if (that.terria.scene.camera.pitch > -1.5260713 && !near2п) {
+                      that.heading = heading + roll;
+                    } else {
+                      that.heading = heading;
+                    }
                 });
             } else {
                 if (that._unsubcribeFromPostRender) {

--- a/Source/ViewModels/NavigationViewModel.js
+++ b/Source/ViewModels/NavigationViewModel.js
@@ -117,7 +117,7 @@ define([
                      * cos(2*n*PI) === 1, where n is natural number
                      *
                      * default camera init is { heading: 0,  pitch: -PI/2, roll: 0 }
-                     * where the -90 pitch causes "look down at earth"
+                     * where the -90 degree pitch causes "look down at earth"
                      *
                      * mouse interaction rarely produces roll "far" from 2*n*PI, but
                      * cesium sets roll value that differs significantly in certain cases,

--- a/Source/ViewModels/NavigationViewModel.js
+++ b/Source/ViewModels/NavigationViewModel.js
@@ -114,12 +114,12 @@ define([
                     /*
                      * "magic" limits for pitch and roll found by trial and error
                      *
-                     * cos(2ⁿPI) === 1, where n is natural number
+                     * cos(2*n*PI) === 1, where n is natural number
                      *
                      * default camera init is { heading: 0,  pitch: -PI/2, roll: 0 }
                      * where the -90 pitch causes "look down at earth"
                      *
-                     * mouse interaction rarely produces roll "far" from 2ⁿPI, but
+                     * mouse interaction rarely produces roll "far" from 2*n*PI, but
                      * cesium sets roll value that differs significantly in certain cases,
                      * when cesium seems to "split" true heading value between heading and roll.
                      */

--- a/Source/ViewModels/NavigationViewModel.js
+++ b/Source/ViewModels/NavigationViewModel.js
@@ -114,19 +114,19 @@ define([
                     /*
                      * "magic" limits for pitch and roll found by trial and error
                      *
-                     * cos(2ⁿп) === 1, where n is natural number
+                     * cos(2ⁿPI) === 1, where n is natural number
                      *
-                     * default camera init is { heading: 0,  pitch: -п/2, roll: 0 }
+                     * default camera init is { heading: 0,  pitch: -PI/2, roll: 0 }
                      * where the -90 pitch causes "look down at earth"
                      *
-                     * mouse interaction rarely produces roll "far" from 2ⁿп, but
+                     * mouse interaction rarely produces roll "far" from 2ⁿPI, but
                      * cesium sets roll value that differs significantly in certain cases,
                      * when cesium seems to "split" true heading value between heading and roll.
                      */
                     var heading = that.terria.scene.camera.heading;
                     var roll = that.terria.scene.camera.roll;
-                    var near2п = CesiumMath.equalsEpsilon(Math.cos(roll), 1, CesiumMath.EPSILON1);
-                    if (that.terria.scene.camera.pitch > -1.5260713 && !near2п) {
+                    var near2PI = CesiumMath.equalsEpsilon(Math.cos(roll), 1, CesiumMath.EPSILON1);
+                    if (that.terria.scene.camera.pitch > -1.5260713 && !near2PI) {
                       that.heading = heading + roll;
                     } else {
                       that.heading = heading;


### PR DESCRIPTION
Fixes [#4118](https://github.com/Novetta/pwcop/issues/4118)

At runtime, this lib is pulled in under `pwcop/aresweb/node_modules/cesium-navigation/`, not under `pwcop/aresweb/packages/fbncjs/cesium/libraries/cesium-navigation/`

How to test:
```
cd $NOVETTA/aresweb/node_modules
rm -rf cesium-navigation
git clone https://github.com/andrewmaach/cesium-navigation.git
cd cesium-navigation
git co bug/4118/compass-flips-north-south
cd $NOVETTA/aresweb
npm run start
```
